### PR TITLE
Enable cache for better cursor response

### DIFF
--- a/autoload/foldpeek.vim
+++ b/autoload/foldpeek.vim
@@ -96,9 +96,8 @@ function! foldpeek#text() abort "{{{1
   let body = s:peekline()
   let [head, tail] = s:decorations()
 
-  let ret = s:return_text(head, body, tail)
   if !empty(s:deprecation_notice())
-    let ret .= s:deprecation_notice()
+    let tail .= s:deprecation_notice()
   endif
 
   if !g:foldpeek#cache#disable

--- a/autoload/foldpeek.vim
+++ b/autoload/foldpeek.vim
@@ -88,9 +88,11 @@ function! foldpeek#text() abort "{{{1
   let body = s:peekline()
   let [head, tail] = s:decorations()
 
-  return !empty(s:deprecation_notice())
+  let ret = !empty(s:deprecation_notice())
         \ ? s:deprecation_notice()
         \ : s:return_text(head, body, tail)
+
+  return ret
 endfunction
 
 function! s:peekline() abort "{{{2

--- a/autoload/foldpeek.vim
+++ b/autoload/foldpeek.vim
@@ -52,6 +52,7 @@ endfunction
 call s:set_default('g:foldpeek#maxspaces', &shiftwidth)
 call s:set_default('g:foldpeek#auto_foldcolumn', 0)
 call s:set_default('g:foldpeek#maxwidth','&textwidth > 0 ? &tw : 79')
+call s:set_default('g:foldpeek#cache#disable', 0)
 
 call s:set_default('g:foldpeek#head', 'foldpeek#default#head()')
 call s:set_default('g:foldpeek#tail', 'foldpeek#default#tail()')
@@ -81,6 +82,11 @@ function! foldpeek#status() abort "{{{1
 endfunction
 
 function! foldpeek#text() abort "{{{1
+  let ret = foldpeek#cache#text()
+  if !empty(ret)
+    return ret
+  endif
+
   if g:foldpeek#auto_foldcolumn && v:foldlevel > (&foldcolumn - 1)
     let &foldcolumn = v:foldlevel + 1
   endif
@@ -91,6 +97,8 @@ function! foldpeek#text() abort "{{{1
   let ret = !empty(s:deprecation_notice())
         \ ? s:deprecation_notice()
         \ : s:return_text(head, body, tail)
+
+  call foldpeek#cache#update(ret, s:offset)
 
   return ret
 endfunction

--- a/autoload/foldpeek.vim
+++ b/autoload/foldpeek.vim
@@ -100,9 +100,10 @@ function! foldpeek#text() abort "{{{1
     let tail .= s:deprecation_notice()
   endif
 
+  let ret = s:return_text(head, body, tail)
   if !g:foldpeek#cache#disable
     let dict = {
-          \ 'text': ret,
+          \ 'foldtext': ret,
           \ 'offset': s:offset,
           \ 'textwidth': s:textwidth,
           \ }

--- a/autoload/foldpeek.vim
+++ b/autoload/foldpeek.vim
@@ -73,6 +73,13 @@ call s:set_default('g:foldpeek#whiteout#disabled_styles', [])
 call s:set_default('g:foldpeek#whiteout#overrided_styles', [])
 call s:set_default('g:foldpeek#whiteout#style_for_foldmarker', 'omit')
 
+function! foldpeek#status() abort "{{{1
+  return {
+        \ 'lnum': s:lnum,
+        \ 'offset': s:offset,
+        \ }
+endfunction
+
 function! foldpeek#text() abort "{{{1
   if g:foldpeek#auto_foldcolumn && v:foldlevel > (&foldcolumn - 1)
     let &foldcolumn = v:foldlevel + 1
@@ -99,14 +106,15 @@ function! s:peekline() abort "{{{2
     endif
 
     if !s:has_skip_patterns(line)
-      let g:foldpeek_lnum = offset + 1
+      let s:offset = offset
+      let s:lnum = offset + 1
       return line
     endif
 
     let offset += 1
   endwhile
 
-  let g:foldpeek_lnum = 1
+  let s:lnum = 1
   return getline(v:foldstart)
 endfunction
 
@@ -130,7 +138,7 @@ function! s:decorations() abort "{{{2
   let tail = get(b:, 'foldpeek_tail', g:foldpeek#tail)
 
   for num in keys(head)
-    if g:foldpeek_lnum >= num
+    if s:lnum >= num
       let head = exists('b:foldpeek_head')
             \ ? b:foldpeek_head[num]
             \ : g:foldpeek#head[num]
@@ -138,7 +146,7 @@ function! s:decorations() abort "{{{2
   endfor
 
   for num in keys(tail)
-    if g:foldpeek_lnum >= num
+    if s:lnum >= num
       let tail = exists('b:foldpeek_tail')
             \ ? b:foldpeek_tail[num]
             \ : g:foldpeek#tail[num]

--- a/autoload/foldpeek/cache.vim
+++ b/autoload/foldpeek/cache.vim
@@ -31,9 +31,6 @@ function! foldpeek#cache#text(lnum) abort "{{{1
 endfunction
 
 function! s:cache.return() abort  "{{{2
-  if !exists('w:foldpeek_folds')
-    let w:foldpeek_folds = {}
-  endif
   let self.folds = w:foldpeek_folds
   let self.tracking_fold = get(w:foldpeek_folds, s:foldstart, {})
 

--- a/autoload/foldpeek/cache.vim
+++ b/autoload/foldpeek/cache.vim
@@ -1,6 +1,6 @@
 " Helper Functions {{{1
 function! s:update_all_folds() abort
-  " Expects to be used for s:caches.is_updating()
+  " Expects to be used for s:is_cache_updating()
   let s:update_pos = v:foldstart
 endfunction
 "}}}1
@@ -32,8 +32,18 @@ endfunction
 function! s:has_changed(cache) abort "{{{2
   if s:foldend != a:cache.foldend
     return 1
-  elseif s:is_updating()
-    return s:compare_lines(a:cache, s:foldend)
+
+  elseif s:is_cache_updating()
+    " FIXME: Use the other logic below after the problem is fixed that folds
+    " with git-diff status often fails to appear at first fold update to be in
+    " cache.
+    "
+    " return len(a:cache.lines) < (s:foldend - s:foldstart)
+    "      \ ? s:compare_lines(a:cache, s:foldend)
+    "      \ : 1
+
+    return 1
+
   elseif s:has_git_updated()
     return 1
   endif
@@ -55,7 +65,9 @@ function! s:compare_lines(cache, depth) abort "{{{3
   return 0
 endfunction
 
-function! s:is_updating() abort "{{{3
+function! s:is_cache_updating() abort "{{{3
+  " Use it with s:update_all_folds(); this function should be only for test.
+
   if !exists('s:update_pos')
     return 0
   endif

--- a/autoload/foldpeek/cache.vim
+++ b/autoload/foldpeek/cache.vim
@@ -105,7 +105,7 @@ function! foldpeek#cache#text(lnum) abort "{{{1
 endfunction
 
 function! s:cache.return() abort  "{{{2
-  let self.folds = w:foldpeek_folds
+  let self.folds = get(w:, 'foldpeek_folds', [])
   let self.tracking_fold = get(self.folds, s:foldstart, {})
 
   if self.is_available()

--- a/autoload/foldpeek/cache.vim
+++ b/autoload/foldpeek/cache.vim
@@ -32,7 +32,7 @@ endfunction
 
 function! s:cache.return() abort  "{{{2
   let self.folds = w:foldpeek_folds
-  let self.tracking_fold = get(w:foldpeek_folds, s:foldstart, {})
+  let self.tracking_fold = get(self.folds, s:foldstart, {})
 
   if self.is_available()
     call self.refresh()

--- a/autoload/foldpeek/cache.vim
+++ b/autoload/foldpeek/cache.vim
@@ -12,10 +12,16 @@ function! foldpeek#cache#text(lnum) abort "{{{1
   let folds = get(w:, 'foldpeek_folds', {})
   let cache = get(folds, s:foldstart, {})
 
-  if s:has_cache(cache) && !s:has_changed(cache)
-    let folds = s:refresh_caches(folds)
+  if s:is_cache_available(cache)
+    call s:refresh_caches(w:foldpeek_folds)
     return cache.return
   endif
+endfunction
+
+function! s:is_cache_available(cache) abort
+  return exists('w:foldpeek_folds')
+        \ && s:has_cache(a:cache)
+        \ && !s:has_text_changed(a:cache)
 endfunction
 
 function! s:has_cache(cache) abort "{{{2

--- a/autoload/foldpeek/cache.vim
+++ b/autoload/foldpeek/cache.vim
@@ -146,9 +146,10 @@ function! foldpeek#cache#update(dict) abort "{{{1
         \ }
 
   let lnum = v:foldstart
-  let max_lnum = g:foldpeek#cache#max_saved_offset < (v:foldend - v:foldstart)
-       \ ? v:foldstart + g:foldpeek#cache#max_saved_offset
-       \ : v:foldend
+  " let max_lnum = g:foldpeek#cache#max_saved_offset < (v:foldend - v:foldstart)
+  "      \ ? v:foldstart + g:foldpeek#cache#max_saved_offset
+  "      \ : v:foldend
+  let max_lnum = lnum + a:dict.offset
   while lnum <= max_lnum
     call add(dict.lines, getline(lnum))
     let lnum += 1

--- a/autoload/foldpeek/cache.vim
+++ b/autoload/foldpeek/cache.vim
@@ -1,0 +1,56 @@
+let s:caches = {}
+
+function! foldpeek#cache#text() abort "{{{1
+  let cache = get(s:caches, v:foldstart, {})
+  if !s:has_cache(cache) || !s:has_changed(cache)
+    return cache.return
+  endif
+endfunction
+
+function! s:has_cache(cache) abort
+  let ret = get(a:cache, 'return')
+  return !empty(ret)
+endfunction
+
+function! s:has_changed(cache) abort "{{{2
+  if g:foldpeek#cache#disable
+        \ || (v:foldend != a:cache.foldend)
+    return 1
+  endif
+
+  if exists('*foldpeek#git#status')
+    " TODO: update as git's status, too
+  endif
+
+  let lnum = v:foldstart
+  let peeked_lnum = v:foldstart + a:cache.offset
+  while lnum < peeked_lnum
+    let lnum += 1
+    if getline(lnum) !=# a:cache[lnum]
+      return 1
+    endif
+  endwhile
+
+  return 0
+endfunction
+
+function! foldpeek#cache#update(text, offset) abort "{{{1
+  " Extends a key, v:foldstart, with dict as {v:foldstart : dict}
+  let dict = {
+        \ 'return' : a:text,
+        \ 'offset' : a:offset,
+        \ 'foldend': v:foldend,
+        \ }
+
+  let lnum = v:foldstart
+  while lnum < (v:foldstart + a:offset)
+    " {v:foldstart     : getline(v:foldstart)    },
+    " {v:foldstart + 1 : getline(v:foldstart + 1)},
+    " ...
+    " {v:foldstart + s:offset : getline(v:foldstart + a:offset)}
+    call extend(dict, {lnum : getline(lnum)})
+    let lnum += 1
+  endwhile
+
+  call extend(s:caches, {v:foldstart : dict})
+endfunction

--- a/autoload/foldpeek/cache.vim
+++ b/autoload/foldpeek/cache.vim
@@ -1,3 +1,5 @@
+let s:cache = {}
+
 " Helper Functions {{{1
 function! s:update_all_folds() abort
   " Expects to be used for s:is_cache_updating()
@@ -9,31 +11,39 @@ function! foldpeek#cache#text(lnum) abort "{{{1
   let s:foldstart = foldclosed(a:lnum)
   let s:foldend = foldclosedend(a:lnum)
 
-  let folds = get(w:, 'foldpeek_folds', {})
-  let cache = get(folds, s:foldstart, {})
+  return s:cache.return()
+endfunction
 
-  if s:is_cache_available(cache)
-    call s:refresh_caches(w:foldpeek_folds)
-    return cache.return
+function! s:cache.return() abort  "{{{2
+  if !exists('w:foldpeek_folds')
+    let w:foldpeek_folds = {}
   endif
+  let self.folds = w:foldpeek_folds
+  let self.tracking_fold = get(w:foldpeek_folds, s:foldstart, {})
+
+  if self.is_available()
+    call self.refresh()
+    return self.tracking_fold.return
+  endif
+
+  return {}
 endfunction
 
-function! s:is_cache_available(cache) abort
-  return exists('w:foldpeek_folds')
-        \ && s:has_cache(a:cache)
-        \ && !s:has_text_changed(a:cache)
+function! s:cache.is_available() abort  "{{{2
+  return self.is_saved()
+        \ && !self.has_text_changed()
 endfunction
 
-function! s:has_cache(cache) abort "{{{2
-  let ret = get(a:cache, 'return')
+function! s:cache.is_saved() abort  "{{{2
+  let ret = get(self.tracking_fold, 'return')
   return !empty(ret)
 endfunction
 
-function! s:has_changed(cache) abort "{{{2
-  if s:foldend != a:cache.foldend
+function! s:cache.has_text_changed() abort  "{{{2
+  if s:foldend != self.tracking_fold.foldend
     return 1
 
-  elseif s:is_cache_updating()
+  elseif self.is_updating()
     " FIXME: Use the other logic below after the problem is fixed that folds
     " with git-diff status often fails to appear at first fold update to be in
     " cache.
@@ -44,19 +54,20 @@ function! s:has_changed(cache) abort "{{{2
 
     return 1
 
-  elseif s:has_git_updated()
+  elseif self.compare_lines()
     return 1
   endif
 
-  return s:compare_lines(a:cache.lines, s:cache.offset)
+  return s:has_git_updated()
 endfunction
 
-function! s:compare_lines(lines, offset) abort "{{{3
+function! s:cache.compare_lines() abort  "{{{2
   let offset = 0
-  let max = a:offset
+  let max = self.tracking_fold.offset
+  let cached_lines = self.tracking_fold.lines
   while offset <= max
     let lnum = s:foldstart + offset
-    if getline(lnum) !=# a:lines[offset]
+    if getline(lnum) !=# cached_lines[offset]
       return 1
     endif
 
@@ -66,7 +77,7 @@ function! s:compare_lines(lines, offset) abort "{{{3
   return 0
 endfunction
 
-function! s:is_cache_updating() abort "{{{3
+function! s:cache.is_updating() abort "{{{2
   " Use it with s:update_all_folds(); this function should be only for test.
 
   if !exists('s:update_pos')
@@ -80,7 +91,7 @@ function! s:is_cache_updating() abort "{{{3
   return 1
 endfunction
 
-function! s:has_git_updated() abort "{{{3
+function! s:has_git_updated() abort "{{{2
   " TODO: Pick up a fold which contains any change to update.
   if !exists('g:autoloaded_foldpeek_git')
         \ || !exists('*GitGutterGetHunkSummary()')
@@ -95,8 +106,8 @@ function! s:has_git_updated() abort "{{{3
   return 1
 endfunction
 
-function! s:refresh_caches(cache) abort "{{{2
-  return filter(a:cache,
+function! s:cache.refresh() abort "{{{2
+  return filter(self.folds,
         \ 'foldclosed(v:key) == v:key'
         \ .' && v:key >= line("w0")'
         \ .' && v:key <= line("w$")'

--- a/autoload/foldpeek/cache.vim
+++ b/autoload/foldpeek/cache.vim
@@ -104,7 +104,7 @@ function! foldpeek#cache#text(lnum) abort "{{{1
   return s:cache.return()
 endfunction
 
-function! s:cache.return() abort  "{{{2
+function! s:cache.return() abort "{{{2
   let self.folds = get(w:, 'foldpeek_folds', [])
   let self.tracking_fold = get(self.folds, s:foldstart, {})
 

--- a/autoload/foldpeek/cache.vim
+++ b/autoload/foldpeek/cache.vim
@@ -24,11 +24,11 @@ function! s:has_changed(cache) abort "{{{2
 
   let lnum = v:foldstart
   let peeked_lnum = v:foldstart + a:cache.offset
-  while lnum < peeked_lnum
-    let lnum += 1
-    if getline(lnum) !=# a:cache[lnum]
+  while lnum <= peeked_lnum
+    if getline(lnum) !=# a:cache.lines[lnum]
       return 1
     endif
+    let lnum += 1
   endwhile
 
   return 0
@@ -37,18 +37,19 @@ endfunction
 function! foldpeek#cache#update(text, offset) abort "{{{1
   " Extends a key, v:foldstart, with dict as {v:foldstart : dict}
   let dict = {
-        \ 'return' : a:text,
-        \ 'offset' : a:offset,
+        \ 'return':  a:text,
+        \ 'offset':  a:offset,
         \ 'foldend': v:foldend,
+        \ 'lines':   {},
         \ }
 
   let lnum = v:foldstart
-  while lnum < (v:foldstart + a:offset)
+  while lnum <= (v:foldstart + a:offset)
     " {v:foldstart     : getline(v:foldstart)    },
     " {v:foldstart + 1 : getline(v:foldstart + 1)},
     " ...
     " {v:foldstart + s:offset : getline(v:foldstart + a:offset)}
-    call extend(dict, {lnum : getline(lnum)})
+    call extend(dict.lines, {lnum : getline(lnum)})
     let lnum += 1
   endwhile
 

--- a/autoload/foldpeek/cache.vim
+++ b/autoload/foldpeek/cache.vim
@@ -134,11 +134,12 @@ function! s:cache.refresh() abort "{{{2
         \ )
 endfunction
 
-function! foldpeek#cache#update(text, offset) abort "{{{1
-  " Extends a key, v:foldstart, with dict as {v:foldstart : dict}
+function! foldpeek#cache#update(dict) abort "{{{1
+  " Extends a key, s:foldstart, with dict as {s:foldstart : dict}
+
   let dict = {
-        \ 'return': a:text,
-        \ 'offset': a:offset,
+        \ 'return': a:dict.foldtext,
+        \ 'offset': a:dict.offset,
         \ 'foldstart': v:foldstart,
         \ 'foldend': v:foldend,
         \ 'lines': [],

--- a/autoload/foldpeek/cache.vim
+++ b/autoload/foldpeek/cache.vim
@@ -94,8 +94,8 @@ function! s:has_git_updated() abort "{{{3
   return 1
 endfunction
 
-function! s:refresh_caches(folds) abort "{{{2
-  return filter(a:folds,
+function! s:refresh_caches(cache) abort "{{{2
+  return filter(a:cache,
         \ 'foldclosed(v:key) == v:key'
         \ .' && v:key >= line("w0")'
         \ .' && v:key <= line("w$")'

--- a/autoload/foldpeek/cache.vim
+++ b/autoload/foldpeek/cache.vim
@@ -2,7 +2,10 @@ let s:caches = {}
 
 function! foldpeek#cache#text() abort "{{{1
   let cache = get(s:caches, v:foldstart, {})
-  if !s:has_cache(cache) || !s:has_changed(cache)
+
+  if !s:has_cache(cache)
+    return ''
+  elseif !s:has_changed(cache)
     return cache.return
   endif
 endfunction

--- a/autoload/foldpeek/cache.vim
+++ b/autoload/foldpeek/cache.vim
@@ -112,7 +112,8 @@ function! s:cache.compare_lines() abort  "{{{2
 endfunction
 
 function! s:has_git_updated() abort "{{{2
-  " TODO: Pick up a fold which contains any change to update.
+  " TODO: Accept other diff-management plugins like coc-git, vim-signify.
+  " The src should be managed in autoload/foldpeek/git.vim.
   if !exists('g:autoloaded_foldpeek_git')
         \ || !exists('*GitGutterGetHunkSummary()')
         \ || (GitGutterGetHunkSummary()

--- a/autoload/foldpeek/cache.vim
+++ b/autoload/foldpeek/cache.vim
@@ -7,7 +7,7 @@ function! foldpeek#cache#text() abort "{{{1
   endif
 endfunction
 
-function! s:has_cache(cache) abort
+function! s:has_cache(cache) abort "{{{2
   let ret = get(a:cache, 'return')
   return !empty(ret)
 endfunction

--- a/autoload/foldpeek/cache.vim
+++ b/autoload/foldpeek/cache.vim
@@ -84,21 +84,22 @@ function! s:textwidth.has_winwidth_changed() abort "{{{3
   return 0
 endfunction
 
-function! s:cache.has_text_changed() abort  "{{{2
-  if s:foldend != self.tracking_fold.foldend
+let s:text_diff = {} "{{{2
+function! s:text_diff.has_changed() abort  "{{{3
+  if s:foldend != s:cache.tracking_fold.foldend
     return 1
 
   elseif self.compare_lines()
     return 1
   endif
 
-  return s:has_git_updated()
+  return self.has_git_updated()
 endfunction
 
-function! s:cache.compare_lines() abort  "{{{2
+function! s:text_diff.compare_lines() abort  "{{{3
   let offset = 0
-  let max = self.tracking_fold.offset
-  let cached_lines = self.tracking_fold.lines
+  let max = s:cache.tracking_fold.offset
+  let cached_lines = s:cache.tracking_fold.lines
   while offset <= max
     let lnum = s:foldstart + offset
     if getline(lnum) !=# cached_lines[offset]
@@ -111,7 +112,7 @@ function! s:cache.compare_lines() abort  "{{{2
   return 0
 endfunction
 
-function! s:has_git_updated() abort "{{{2
+function! s:text_diff.has_git_updated() abort "{{{3
   " TODO: Accept other diff-management plugins like coc-git, vim-signify.
   " The src should be managed in autoload/foldpeek/git.vim.
   if !exists('g:autoloaded_foldpeek_git')

--- a/autoload/foldpeek/cache.vim
+++ b/autoload/foldpeek/cache.vim
@@ -50,7 +50,7 @@ function! s:is_updating() abort "{{{3
     return 0
   endif
 
-  if v:foldstart <= s:update_pos
+  if v:foldstart > s:update_pos
     unlet s:update_pos
   endif
 

--- a/autoload/foldpeek/cache.vim
+++ b/autoload/foldpeek/cache.vim
@@ -21,38 +21,6 @@ function! s:update_all_folds.in_progress() abort
 
   return 1
 endfunction
-"}}}1
-
-function! foldpeek#cache#text(lnum) abort "{{{1
-  let s:foldstart = foldclosed(a:lnum)
-  let s:foldend = foldclosedend(a:lnum)
-
-  return s:cache.return()
-endfunction
-
-function! s:cache.return() abort  "{{{2
-  let self.folds = w:foldpeek_folds
-  let self.tracking_fold = get(self.folds, s:foldstart, {})
-
-  if self.is_available()
-    call self.refresh()
-    return self.tracking_fold.return
-  endif
-
-  return {}
-endfunction
-
-function! s:cache.is_available() abort  "{{{2
-  return self.is_saved()
-        \ && !s:update_all_folds.in_progress()
-        \ && !s:textwidth.is_changed()
-        \ && !self.has_text_changed()
-endfunction
-
-function! s:cache.is_saved() abort  "{{{2
-  let ret = get(self.tracking_fold, 'return')
-  return !empty(ret)
-endfunction
 
 let s:textwidth = {} "{{{2
 function! s:textwidth.is_changed() abort "{{{3
@@ -126,6 +94,38 @@ function! s:text_diff.has_git_updated() abort "{{{3
   call s:update_all_folds.prepare()
 
   return 1
+endfunction
+"}}}1
+
+function! foldpeek#cache#text(lnum) abort "{{{1
+  let s:foldstart = foldclosed(a:lnum)
+  let s:foldend = foldclosedend(a:lnum)
+
+  return s:cache.return()
+endfunction
+
+function! s:cache.return() abort  "{{{2
+  let self.folds = w:foldpeek_folds
+  let self.tracking_fold = get(self.folds, s:foldstart, {})
+
+  if self.is_available()
+    call self.refresh()
+    return self.tracking_fold.return
+  endif
+
+  return {}
+endfunction
+
+function! s:cache.is_available() abort  "{{{2
+  return self.is_saved()
+        \ && !s:update_all_folds.in_progress()
+        \ && !s:textwidth.is_changed()
+        \ && !s:text_diff.has_changed()
+endfunction
+
+function! s:cache.is_saved() abort  "{{{2
+  let ret = get(self.tracking_fold, 'return')
+  return !empty(ret)
 endfunction
 
 function! s:cache.refresh() abort "{{{2

--- a/autoload/foldpeek/git.vim
+++ b/autoload/foldpeek/git.vim
@@ -10,18 +10,18 @@ function! foldpeek#git#get_diff(...) abort "{{{1
   return get(s:get_git_stat(lnum), 'diff')
 endfunction
 
-function! s:git_stat(...) abort "{{{1
-  if a:0 == 0
-    let s:foldstart = v:foldstart
-    let s:foldend = v:foldend
-
-  elseif foldclosed(a:1) == -1
-    return 'Invalid Number:'. a:1 .'belongs to no fold'
+function! s:update_tracking_fold(lnum) abort "{{{1
+  if foldclosed(a:lnum) == -1
+    throw 'Invalid Number: '. a:lnum .' belongs to no fold'
 
   else
-    let s:foldstart = foldclosed(a:1)
-    let s:foldend = foldclosedend(a:1)
+    let s:foldstart = foldclosed(a:lnum)
+    let s:foldend = foldclosedend(a:lnum)
   endif
+endfunction
+
+function! s:get_git_stat(lnum) abort "{{{1
+  call s:update_tracking_fold(a:lnum)
 
   if s:is_cache_available()
     call s:refresh_caches(w:foldpeek_git)
@@ -30,7 +30,7 @@ function! s:git_stat(...) abort "{{{1
 
   call s:set_git_stat_as_signs()
   call s:update_cache()
-  return extend(s:git_stat, {'cached': 0})
+  return extend(w:foldpeek_git[s:foldstart], {'cached': 0})
 endfunction
 
 function! s:is_cache_available() abort "{{{2

--- a/autoload/foldpeek/git.vim
+++ b/autoload/foldpeek/git.vim
@@ -2,15 +2,15 @@ let g:autoloaded_foldpeek_git = 1
 
 function! foldpeek#git#has_diff(...) abort "{{{1
   let lnum = a:0 > 0 ? a:1 : v:foldstart
-  return foldpeek#git#status(lnum).has_diff
+  return s:git_stat(lnum).has_diff
 endfunction
 
 function! foldpeek#git#get_diff(...) abort "{{{1
   let lnum = a:0 > 0 ? a:1 : v:foldstart
-  return foldpeek#git#status(lnum).diff
+  return s:git_stat(lnum).diff
 endfunction
 
-function! foldpeek#git#status(...) abort "{{{1
+function! s:git_stat(...) abort "{{{1
   if a:0 == 0
     let s:foldstart = v:foldstart
     let s:foldend = v:foldend
@@ -84,7 +84,7 @@ function! s:set_git_stat_as_signs() abort "{{{2
         let git_stat.has_diff = (sign.name =~# l:key)
       endif
       " e.g., git_stat['Added'] += ('GitGutterLineAdded' =~# 'Added')
-      if sign.name =~# 'Modified'
+      if sign.name =~# 'Modified\|Change'
         " Take care of combined named signs like 'GitGutterLineModifiedRemoved'
         let diff[l:key] += l:key =~# 'Modified'
       elseif sign.name =~# 'Added'

--- a/autoload/foldpeek/git.vim
+++ b/autoload/foldpeek/git.vim
@@ -2,12 +2,12 @@ let g:autoloaded_foldpeek_git = 1
 
 function! foldpeek#git#has_diff(...) abort "{{{1
   let lnum = a:0 > 0 ? a:1 : v:foldstart
-  return s:git_stat(lnum).has_diff
+  return get(s:get_git_stat(lnum), 'has_diff')
 endfunction
 
 function! foldpeek#git#get_diff(...) abort "{{{1
   let lnum = a:0 > 0 ? a:1 : v:foldstart
-  return s:git_stat(lnum).diff
+  return get(s:get_git_stat(lnum), 'diff')
 endfunction
 
 function! s:git_stat(...) abort "{{{1

--- a/doc/foldpeek.txt
+++ b/doc/foldpeek.txt
@@ -5,7 +5,7 @@ Author: kaile256 <kaile256acc at gmail.com>
 License: MIT license
 
 ==============================================================================
-CONTENTS						  *foldpeek-contents*
+CONTENTS						    *foldpeek-contents*
 
 Introduction			|foldpeek-introduction|
 Overview			|foldpeek-overview|
@@ -28,11 +28,13 @@ Latest version:
 https://github.com/kaile256/vim-foldpeek
 
 ==============================================================================
-OVERVIEW						   *foldpeek-overview*
+OVERVIEW						    *foldpeek-overview*
 
 |foldpeek| provides some functions and variables to configure. Read the
 details in |foldpeek-interface|.
 The functions:
+------------------------------------------------------------------------------
+FUNCTION					   *foldpeek-overview-function*
 
 | `foldpeek#text()`          | the main function for 'foldtext'   |
 | `foldpeek#head()`          | used in |g:foldpeek#head| as default |
@@ -40,12 +42,8 @@ The functions:
 | `foldpeek#hunk_info()`     | see |foldpeek-overview-git|          |
 | `foldpeek#has_any_hunks()` | see |foldpeek-overview-git|          |
 
-The variables:
-
-| |g:foldpeek#local_only|                    | FoldPeek won't set 'foldtext' |
-| |g:foldpeek#auto_foldcolumn|               |                                   |
-| |g:foldpeek#skip_patterns|                 | patterns to the next line in fold |
-| |g:foldpeek#override_skip_patterns|        | only use b:foldpeek_skip_patterns |
+------------------------------------------------------------------------------
+VARIABLE					   *foldpeek-overview-variable*
 
 | |g:foldpeek#indent_with_head|              | modify fold head as indent        |
 | |g:foldpeek#head|                          | decorate head of folded line      |
@@ -63,6 +61,9 @@ The variables:
 
 Most of the variables have buffer-local ones respectively like
 |b:foldpeek_skip_patterns|. Follow the tags for more detail.
+
+------------------------------------------------------------------------------
+FEATURE						    *foldpeek-overview-feature*
 
 whiteout					   *foldpeek-overview-whiteout*
 	Currently, |foldpeek| supports the styles:
@@ -97,12 +98,12 @@ git							*foldpeek-overview-git*
 	"https://github.com/airblade/vim-gitgutter".
 
 ==============================================================================
-INTERFACE						 *foldpeek-interface*
+INTERFACE						   *foldpeek-interface*
 
 ------------------------------------------------------------------------------
-FUNCTION						   *foldpeek-function*
+FUNCTION						    *foldpeek-function*
 
-foldpeek#text()					    *foldpeek-foldpeek#text()*
+foldpeek#text						       *foldpeek#text()*
 	Unless |g:foldpeek#local_only| is set to 1, this function will be set in
 	'foldtext'. For local use, add
 >
@@ -110,8 +111,8 @@ foldpeek#text()					    *foldpeek-foldpeek#text()*
 <
 	in your vimrc with |autocmd| or under ftplugin/foo.vim.
 
-foldpeek#default#head()			     *foldpeek-foldpeek#default#head()*
-foldpeek#default#tail() 		     *foldpeek-foldpeek#default#tail()*
+foldpeek#default#head()				       *foldpeek#default#head()*
+foldpeek#default#tail() 		     	       *foldpeek#default#tail()*
 	The default functions for |g:foldpeek#head| and |g:foldpeek#tail|.
 	You can overwrite them with {expr} like
 >
@@ -130,9 +131,9 @@ foldpeek#has_any_hunks()			    *foldpeek#has_any_hunks()*
 	Note: The feature depends on another plugin; see |foldpeek-overview-git|.
 
 ------------------------------------------------------------------------------
-VARIABLES						  *foldpeek-variable*
+VARIABLE						    *foldpeek-variable*
 
-g:foldpeek#local_only				      *g:foldpeek#local_only*
+g:foldpeek#local_only					*g:foldpeek#local_only*
 	(default: 0)
 	If not 0, |foldpeek#text()| won't be set in &foldtext unless
 >
@@ -140,19 +141,19 @@ g:foldpeek#local_only				      *g:foldpeek#local_only*
 <
 	in your vimrc or in commandline.
 
-g:foldpeek#maxwidth					*g:foldpeek#maxwidth*
+g:foldpeek#maxwidth					  *g:foldpeek#maxwidth*
 	(default: "&textwidth > 0 ? &tw : 79")
 	Set in |Number| or |String|. The value will be evaluated.
 	|foldpeek#text()| will keep foldtext, including head and tail, within
 	the column as is evaluated.
 
-g:foldpeek#auto_foldcolumn			 *g:foldpeek#auto_foldcolumn*
+g:foldpeek#auto_foldcolumn			   *g:foldpeek#auto_foldcolumn*
 	(default: 0)
 	If not `0`, increase |&foldcolumn| as the highest v:foldlevel of current
 	buffer.
 
-g:foldpeek#skip_patterns			   *g:foldpeek#skip_patterns*
-b:foldpeek_skip_patterns			   *b:foldpeek_skip_patterns*
+g:foldpeek#skip#patterns			     *g:foldpeek#skip#patterns*
+b:foldpeek_skip_patterns			     *b:foldpeek_skip_patterns*
 	(default: ['^[>#\-=/{!* \t]*$'])
 	Set in |List|.
 	This value will be compared to the folded lines in regexp match. Check
@@ -162,8 +163,14 @@ b:foldpeek_skip_patterns			   *b:foldpeek_skip_patterns*
 	<Tab> and pair out of 'foldmarker' with &commentstring (without `%s`)
 	close to those is regarded as whitespaces on the comparison.
 
-g:foldpeek#indent_with_head			*g:foldpeek#indent_with_head*
-b:foldpeek_indent_with_head			*b:foldpeek_indent_with_head*
+g:foldpeek#skip_patterns			     *g:foldpeek#skip_patterns*
+	(Deprecated)
+
+g:foldpeek#skip#override_patterns	    *g:foldpeek#skip#override_patterns*
+b:foldpeek_skip_override_patterns	    *b:foldpeek_skip_override_patterns*
+
+g:foldpeek#indent_with_head			  *g:foldpeek#indent_with_head*
+b:foldpeek_indent_with_head			  *b:foldpeek_indent_with_head*
 	(default: 0)
 	Set in |Number|.
 	If 0, head of foldtext which is returned by |g:foldpeek#head| or
@@ -172,8 +179,8 @@ b:foldpeek_indent_with_head			*b:foldpeek_indent_with_head*
 	otherwise, head will be shown at the first character of the line where
 	you get by "0" in normal mode.
 
-g:foldpeek#head						    *g:foldpeek#head*
-b:foldpeek_head						    *b:foldpeek_head*
+g:foldpeek#head						      *g:foldpeek#head*
+b:foldpeek_head						      *b:foldpeek_head*
 	(default: "foldpeek#default#head()"
 	Set in |String|. The value will be evaluated if possible.
 	Replace heads of foldtext with the value.
@@ -183,22 +190,22 @@ b:foldpeek_head						    *b:foldpeek_head*
 <
 	in your vimrc and keep it empty.
 
-g:foldpeek#tail						    *g:foldpeek#tail*
-b:foldpeek_tail						    *b:foldpeek_tail*
+g:foldpeek#tail						      *g:foldpeek#tail*
+b:foldpeek_tail						      *b:foldpeek_tail*
 	(default: "foldpeek#default#tail()"
 	Set in |String|. The value will be evaluated if possible.
 	Replace tails of foldtext with the value, at the column decided by
 	|g:foldpeek#maxwidth|.
 
-g:foldpeek#table					    *g:foldpeek#table*
+g:foldpeek#table					     *g:foldpeek#table*
 	(Deprecated)
 
-g:foldpeek#disable_whiteout			*g:foldpeek#disable_whiteout*
-b:foldpeek_disable_whiteout			*b:foldpeek_disable_whiteout*
+g:foldpeek#disable_whiteout			  *g:foldpeek#disable_whiteout*
+b:foldpeek_disable_whiteout			  *b:foldpeek_disable_whiteout*
 	(Deprecated)
 
-g:foldpeek#whiteout#patterns			*g:foldpeek#whiteout#patterns*
-b:foldpeek_whiteout_patterns			*b:foldpeek_whiteout_patterns*
+g:foldpeek#whiteout#patterns			 *g:foldpeek#whiteout#patterns*
+b:foldpeek_whiteout_patterns			 *b:foldpeek_whiteout_patterns*
 	(default: {"substitute": [
 		\   ['{\s*$', '{...}', ''],
 		\   ['[\s*$', '[...]', ''],
@@ -231,8 +238,8 @@ g:foldpeek#whiteout_patterns_fill	    *g:foldpeek#whiteout_patterns_fill*
 	(Deprecated)
 	Use |g:foldpeek#whiteout#patterns| instead.
 
-				   *g:foldpeek#whiteout#style_for_foldmarker*
-				   *b:foldpeek_whiteout_style_for_foldmarker*
+				     *g:foldpeek#whiteout#style_for_foldmarker*
+				     *b:foldpeek_whiteout_style_for_foldmarker*
 g:foldpeek#whiteout#style_for_foldmarker
 b:foldpeek_whiteout_style_for_foldmarker
 	(default: "omit")
@@ -249,7 +256,7 @@ b:foldpeek_whiteout_style_for_foldmarker
 	"omit"; the behavior is the same as |g:foldpeek#whiteout_patterns_omit|
 	and so on.
 
-				   *g:foldpeek#whiteout_style_for_foldmarker*
+				     *g:foldpeek#whiteout_style_for_foldmarker*
 g:foldpeek#whiteout_style_for_foldmarker
 	(Deprecated)
 	Use |g:foldpeek#whiteout#style_for_foldmarker| instead.
@@ -260,7 +267,7 @@ g:foldpeek#cache#disable			      *g:foldpeek#cache#disable*
 	Vim/Neovim demands.
 
 ==============================================================================
-FEATURE							    *foldpeek-feature*
+EXAMPLE							      *foldpeek-example*
 
 whiteout					   *foldpeek-feature-whiteout*
 	Currently, vim-foldpeek supports the styles:
@@ -317,7 +324,7 @@ in |g:foldpeek#whiteout_patterns_omit| instead, you will see as below:
 	-#'foo/bar'                                                      [2/2]
 <
 ===============================================================================
-COMPATIBILITY					      *foldpeek-compatibility*
+COMPATIBILITY					        *foldpeek-compatibility*
 
 Deprecated feature will be all removed in the next update after deprecation
 notice.

--- a/doc/foldpeek.txt
+++ b/doc/foldpeek.txt
@@ -254,6 +254,11 @@ g:foldpeek#whiteout_style_for_foldmarker
 	(Deprecated)
 	Use |g:foldpeek#whiteout#style_for_foldmarker| instead.
 
+g:foldpeek#cache#disable			      *g:foldpeek#cache#disable*
+	(Default: 0)
+	If not 0, |foldpeek| always processes foldtext at every folded lines as
+	Vim/Neovim demands.
+
 ==============================================================================
 FEATURE							    *foldpeek-feature*
 

--- a/doc/foldpeek.txt
+++ b/doc/foldpeek.txt
@@ -17,8 +17,12 @@ Example				|foldpeek-example|
 Compatibility			|foldpeek-compatibility|
 
 ==============================================================================
-INTRODUCTION						     *foldpeek-intro*
-	customize your foldtext
+INTRODUCTION						       *foldpeek-intro*
+
+	Peek in folds!
+
+	*foldpeek* lets you get more informations at foldtext.
+	You can get git-diff status in each folds with another plugin.
 
 Latest version:
 https://github.com/kaile256/vim-foldpeek

--- a/doc/foldpeek.txt
+++ b/doc/foldpeek.txt
@@ -30,7 +30,7 @@ https://github.com/kaile256/vim-foldpeek
 ==============================================================================
 OVERVIEW						   *foldpeek-overview*
 
-FoldPeek provides some functions and variables to configure. Read the
+|foldpeek| provides some functions and variables to configure. Read the
 details in |foldpeek-interface|.
 The functions:
 
@@ -65,7 +65,7 @@ Most of the variables have buffer-local ones respectively like
 |b:foldpeek_skip_patterns|. Follow the tags for more detail.
 
 whiteout					   *foldpeek-overview-whiteout*
-	Currently, FoldPeek supports the styles:
+	Currently, |foldpeek| supports the styles:
 
 	left		only show matched patterns.
 	omit		omit matched patterns.
@@ -82,7 +82,7 @@ whiteout					   *foldpeek-overview-whiteout*
 
 git							*foldpeek-overview-git*
 	Watch the changes in each folds.
-	Related functions:
+	|foldpeek| only provides |foldpeek#git#status()|.
 
 	`foldpeek#hunk_info()`
 	`foldpeek#has_any_hunks()`
@@ -336,7 +336,7 @@ notice.
 
 2020.04.28
 * Deprecated: g:foldpeek#head/tail and b:foldpeek_head/tail in Dictionary.
-  FoldPeek will stop to support them in Dictionary; please use them in
+  |foldpeek| will stop to support them in Dictionary; please use them in
   String.
 * Deprecated: g:foldpeek#table will be removed; please override or define
   functions like foldpeek#head() or foldpeek#tail() instead.


### PR DESCRIPTION
Cursor moved too lazy when a number of folds fill windows.

Cache on this pr will update on some conditions:
- when window resizes
- when anything changes between the first line of a fold and its peeked line
- when gitgutter's summary has changed (with gitgutter)